### PR TITLE
Removing the default limit in the default config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -14,7 +14,6 @@ delete_if_not_replicated: false                     # Remove all objects in dest
 batch_size: 10000                                   # Number of items in each batch
 batch_size_datapoints:                              # Number of datapoints in each batch (The SDK will automatically paginate so it's generally not needed with a value here)
 number_of_threads: 10                               # Number of threads to use
-datapoint_limit: 1000000                            # Maximum number of datapoints to fetch per time series
 client_timeout: 120                                 # Seconds for clients to timeout
 client_name: cognite-replicator                     # Name of client
 log_path: log                                       # Folder to save logs to


### PR DESCRIPTION
It seems to affect the copy of the datapoints

