### PR TITLE
Add dp manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Changes are grouped as follows
 
 ## [Unreleased]
 
+## [0.8.0] - 2020-06-19
+
+## Added
+- value_manipluation_lambda_fnc parameter (optional) added to datapoints.replicate function. A lambda function string
+  can be provided. This function takes each datapoint.value and gets applied to each point of a given timeseries.
+  Example: "lambda x: x*15"
+
 ## [0.7.6] - 2020-02-04
 
 ## Fixed

--- a/cognite/replicator/__main__.py
+++ b/cognite/replicator/__main__.py
@@ -170,6 +170,7 @@ def main():
             start=config.get("datapoints_start"),
             end=config.get("datapoints_end"),
             exclude_pattern=config.get("timeseries_exclude_pattern"),
+            value_manipluation_lambda_fnc=config.get("value_manipluation_lambda_fnc")
         )
 
 

--- a/cognite/replicator/datapoints.py
+++ b/cognite/replicator/datapoints.py
@@ -291,6 +291,7 @@ def replicate(
         end: If specified, limits replication to datapoints earlier than the end time
         exclude_pattern: Regex pattern; time series whose names match will not be replicated from
         value_manipluation_lambda_fnc: A basic lambda function can be provided to manipulate datapoints as a string.
+                                        It will be applied to the value of each datapoint in the timeseries.
     """
 
     if external_ids and exclude_pattern:

--- a/config/default.yml
+++ b/config/default.yml
@@ -21,7 +21,7 @@ log_level: INFO                                     # Logging level
 timeseries_exclude_pattern:                         # Regex pattern to prevent replication of matching timeseries. Example: ^SYN_
 datapoints_start: 1546297200                        # Must be an integer timestamp or a "time-ago string" on the format: <integer>(s|m|h|d|w)-ago or 'now'. E.g. '3d-ago' or '1w-ago'
 datapoints_end: 1w-ago                              # Must be an integer timestamp or a "time-ago string" on the format: <integer>(s|m|h|d|w)-ago or 'now'. E.g. '3d-ago' or '1w-ago'
-value_manipluation_lambda_fnc:                      # A basic lambda function can be provided to manipulate datapoints as a string. Example: "lambda x: x+15"
+value_manipluation_lambda_fnc:                      # A basic lambda function can be provided to manipulate datapoints as a string. Will be applied to the value of each data point. Example: "lambda x: x+15"
 timeseries_external_ids:                            # List of timeseries external_ids to replicate
   - external-id-1:value
   - external-id-2:value

--- a/config/default.yml
+++ b/config/default.yml
@@ -21,6 +21,7 @@ log_level: INFO                                     # Logging level
 timeseries_exclude_pattern:                         # Regex pattern to prevent replication of matching timeseries. Example: ^SYN_
 datapoints_start: 1546297200                        # Must be an integer timestamp or a "time-ago string" on the format: <integer>(s|m|h|d|w)-ago or 'now'. E.g. '3d-ago' or '1w-ago'
 datapoints_end: 1w-ago                              # Must be an integer timestamp or a "time-ago string" on the format: <integer>(s|m|h|d|w)-ago or 'now'. E.g. '3d-ago' or '1w-ago'
+value_manipluation_lambda_fnc:                      # A basic lambda function can be provided to manipulate datapoints as a string. Example: "lambda x: x+15"
 timeseries_external_ids:                            # List of timeseries external_ids to replicate
   - external-id-1:value
   - external-id-2:value


### PR DESCRIPTION
Hi, 
I just added a new optional parameter to datapoints.replicate function to be able to pass basic functions for manipulating datapoint values of timeseries provided. 

This parameter can be provided in config files as "value_manipluation_lambda_fnc" and a lambda function can be passed to it. After passing the function as a string, code will evaluate it to a callable and apply it to datapoint values of a given timeseries. (Example: "lambda x: x+15" ) 

We had src_datapoint_transform parameter for datapoint manipulation purposes but it was expecting a callable taking Datapoint object as an input. So it was not possible to handle it with lambda functions. For example, you could write a function like "lambda x: x.value*3". It would change the value but return None. I didn't want to change the logic since it enables us to manipulate the whole Datapoint object and didn't want to break backward compatibility. 

I can explain more and also, I am open to better solutions.