### PR TITLE
Add latest to docker image push

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,4 +27,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: cognite/cognite-replicator:1.0.0
+          tags: cognite/cognite-replicator:latest,cognite/cognite-replicator:1.0.0


### PR DESCRIPTION
Why: Accidentally not use an old docker image.