### PR TITLE
Update Dockerfile to peg the python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3.11-slim of FROM python:3.11.6-slim
 
 LABEL maintainer="support@cognite.com"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim of FROM python:3.11.6-slim
+FROM python:3.11.6-slim
 
 LABEL maintainer="support@cognite.com"
 


### PR DESCRIPTION
The latest upgrade to python version was causing build to fail. So tagging docker file with a version that works. Change from latest 3.12.0 to 3.11.6