### PR TITLE
Remove obsolete APIKey usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10' 
+          python-version: '3.11'
 
       - name: Install Python dependencies
         run: |
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10' 
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10' 
+        python-version: '3.11'
         
     - name: Install dependencies
       run: |

--- a/cognite/replicator/__main__.py
+++ b/cognite/replicator/__main__.py
@@ -28,7 +28,7 @@ import getpass
 import yaml
 from cognite.client import CogniteClient, ClientConfig
 from cognite.client.exceptions import CogniteAPIError
-from cognite.client.credentials import OAuthClientCredentials, Token, OAuthInteractive, APIKey
+from cognite.client.credentials import OAuthClientCredentials, Token, OAuthInteractive
 from cognite.client.data_classes import assets, datapoints, events, files, raw, time_series
 
 # import __init__
@@ -266,7 +266,6 @@ def main():
         src_api_key = os.environ.get(config.get("src_api_key_env_var", "COGNITE_SOURCE_API_KEY"))
         src_client = CogniteClient(
             ClientConfig(
-                credentials=APIKey(src_api_key),
                 project=config.get("src_COGNITE_PROJECT"),
                 client_name=config.get("client_name"),
                 base_url=config.get("src_baseurl", "https://api.cognitedata.com"),
@@ -318,7 +317,6 @@ def main():
         dst_api_key = os.environ.get(config.get("dst_api_key_env_var", "COGNITE_DESTINATION_API_KEY"))
         dst_client = CogniteClient(
             ClientConfig(
-                credentials=APIKey(dst_api_key),
                 project=config.get("dst_COGNITE_PROJECT"),
                 client_name=config.get("client_name"),
                 base_url=config.get("dst_baseurl", "https://api.cognitedata.com"),

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,5 +2,5 @@ build:
     image: latest
 
 python:
-    version: 3.10
+    version: 3.11
     pip_install: true


### PR DESCRIPTION
### Why

* Remove obsolete APIKey usage.
* Upgrade GHA to python 3.11.

![image](https://github.com/cognitedata/cognite-replicator/assets/15628990/6e88cacb-4c8d-471c-ba40-016e2b1ff4ce)
